### PR TITLE
Fixed bytes/str errors in private_markets BitcoinCentral, MtGox with Python3.2

### DIFF
--- a/src/private_markets/bitcoincentral.py
+++ b/src/private_markets/bitcoincentral.py
@@ -46,8 +46,10 @@ class PrivateBitcoinCentral(Market):
                 url, json.dumps(params), headers=headers)
         else:
             req = urllib.request.Request(url, headers=headers)
-        base64string = base64.encodestring('%s:%s' % (
-            self.username, self.password)).replace('\n', '')
+
+        userpass = '%s:%s' % (
+            self.username, self.password)
+        base64string = base64.encodestring(bytes(userpass, "UTF-8")).replace(b'\n',b'')
         req.add_header("Authorization", "Basic %s" % base64string)
         code = 422
         try:

--- a/src/private_markets/mtgox.py
+++ b/src/private_markets/mtgox.py
@@ -71,12 +71,13 @@ class PrivateMtGox(Market):
         return Decimal(amount) / Decimal(100000.)
 
     def _send_request(self, url, params, extra_headers=None):
+        urlparams = bytes(urllib.parse.urlencode(params), "UTF-8")
+        secret_from_b64 = base64.b64decode(bytes(self.secret, "UTF-8"))
+        hmac_secret= hmac.new(secret_from_b64,urlparams, hashlib.sha512)
+        
         headers = {
             'Rest-Key': self.key,
-            'Rest-Sign': base64.b64encode(str(hmac.new(base64.b64decode(self.secret),
-                                                       urllib.parse.urlencode(
-                                                           params), hashlib.sha512).digest(
-                                                           ))),
+            'Rest-Sign': base64.b64encode(hmac_secret.digest()),
             'Content-type': 'application/x-www-form-urlencoded',
             'Accept': 'application/json, text/javascript, */*; q=0.01',
             'User-Agent': 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT)'
@@ -86,11 +87,11 @@ class PrivateMtGox(Market):
                 headers[k] = v
         try:
             req = urllib.request.Request(url[
-                                         'url'], urllib.parse.urlencode(params), headers)
+                                         'url'], bytes(urllib.parse.urlencode(params), "UTF-8"), headers)
             response = urllib.request.urlopen(req)
             if response.getcode() == 200:
                 jsonstr = response.read()
-                return json.loads(jsonstr)
+                return json.loads(str(jsonstr, "UTF-8"))
         except Exception as err:
             logging.error('Can\'t request MTGox, %s' % err)
         return None


### PR DESCRIPTION
Hi, the transtion to Python3 introduced some incompatibilities when dealing with strings and bytes, mainly when dealing with base64. Here's the fix. 
